### PR TITLE
fix(vercel): support SPA environment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
# Description

vercel에서 SPA 환경을 지원하기 위해 어떤 경로로 접속해도 /index.html을 가리킬 수 있도록 하는 설정 파일을 추가합니다.

## As-Is
<img width="1686" alt="Screenshot 2025-06-15 at 02 34 38" src="https://github.com/user-attachments/assets/4076fc89-c5eb-445d-85f0-85e9e2095567" />

## To-Be
<img width="1686" alt="Screenshot 2025-06-15 at 02 36 13" src="https://github.com/user-attachments/assets/2843ce10-d600-4e42-a5b8-efe3475d2a1b" />

# How To Reproduce
- 페이지 이동을 한 뒤에 브라우저를 새로고침하면 404 페이지가 뜹니다.

